### PR TITLE
Updated OpenZeppelin imports

### DIFF
--- a/contracts/ERC3664.sol
+++ b/contracts/ERC3664.sol
@@ -417,6 +417,8 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
         while (values[i] != value) {
             i++;
         }
-        delete values[i];
+        values[i] = values[values.length-1];
+        values.pop();
+        //delete values[i];
     }
 }

--- a/contracts/ERC3664.sol
+++ b/contracts/ERC3664.sol
@@ -2,9 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/utils/Context.sol";
-import "openzeppelin-solidity/contracts/utils/Strings.sol";
-import "openzeppelin-solidity/contracts/utils/introspection/ERC165.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "./IERC3664.sol";
 import "./extensions/IERC3664Metadata.sol";
 

--- a/contracts/ERC3664.sol
+++ b/contracts/ERC3664.sol
@@ -402,7 +402,7 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
     }
 
     function _asSingletonArray(uint256 element)
-        internal
+        internal virtual
         pure
         returns (uint256[] memory)
     {

--- a/contracts/IERC3664.sol
+++ b/contracts/IERC3664.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 /**
  * @dev Required interface of an ERC3664 compliant contract.

--- a/contracts/Synthetic/ISynthetic721.sol
+++ b/contracts/Synthetic/ISynthetic721.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-import "openzeppelin-solidity/contracts/token/ERC721/IERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "./ISynthetic.sol";
 
 /**

--- a/contracts/presets/ERC3664Generic.sol
+++ b/contracts/presets/ERC3664Generic.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import "../ERC3664.sol";
-import "openzeppelin-solidity/contracts/access/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 
 contract ERC3664Generic is ERC3664, AccessControlEnumerable {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");


### PR DESCRIPTION
Updated the OpenZeppelin imports. No longer using the deprecated openzeppelin-solidity and now using @openzeppelin/contracts.