### PR TITLE
Fix: ERC-1155 conflicting functions

### DIFF
--- a/contracts/ERC3664.sol
+++ b/contracts/ERC3664.sol
@@ -204,8 +204,8 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
             operator,
             0,
             tokenId,
-            _asSingletonArray(attrId),
-            _asSingletonArray(amount),
+            _as3664SingletonArray(attrId),
+            _as3664SingletonArray(amount),
             ""
         );
 
@@ -306,8 +306,8 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
             operator,
             tokenId,
             0,
-            _asSingletonArray(attrId),
-            _asSingletonArray(amount),
+            _as3664SingletonArray(attrId),
+            _as3664SingletonArray(amount),
             ""
         );
 
@@ -401,8 +401,8 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
         return attrBalances[attrId][tokenId] > 0;
     }
 
-    function _asSingletonArray(uint256 element)
-        internal virtual
+    function _as3664SingletonArray(uint256 element)
+        internal
         pure
         returns (uint256[] memory)
     {

--- a/contracts/ERC3664.sol
+++ b/contracts/ERC3664.sol
@@ -30,7 +30,7 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
     mapping(uint256 => uint256[]) public attrs;
 
     constructor(string memory uri_) {
-        _setURI(uri_);
+        _setAttrURI(uri_);
     }
 
     /**
@@ -379,7 +379,7 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
      * attribute will be the concatenation of the `_baseUri` and the `attrId`. Empty
      * by default, can be overriden in child contracts.
      */
-    function _setURI(string memory newuri) internal virtual {
+    function _setAttrURI(string memory newuri) internal virtual {
         _baseUri = newuri;
     }
 

--- a/contracts/ERC3664.sol
+++ b/contracts/ERC3664.sol
@@ -419,6 +419,5 @@ contract ERC3664 is Context, ERC165, IERC3664, IERC3664Metadata {
         }
         values[i] = values[values.length-1];
         values.pop();
-        //delete values[i];
     }
 }

--- a/contracts/extensions/ERC3664Transferable.sol
+++ b/contracts/extensions/ERC3664Transferable.sol
@@ -84,8 +84,8 @@ abstract contract ERC3664Transferable is ERC3664, IERC3664Transferable {
             operator,
             from,
             to,
-            _asSingletonArray(attrId),
-            _asSingletonArray(amount),
+            _as3664SingletonArray(attrId),
+            _as3664SingletonArray(amount),
             ""
         );
 

--- a/contracts/extensions/ERC3664Updatable.sol
+++ b/contracts/extensions/ERC3664Updatable.sol
@@ -25,8 +25,8 @@ abstract contract ERC3664Updatable is ERC3664, IERC3664Updatable {
             operator,
             tokenId,
             0,
-            _asSingletonArray(attrId),
-            _asSingletonArray(amount),
+            _as3664SingletonArray(attrId),
+            _as3664SingletonArray(amount),
             ""
         );
 
@@ -58,8 +58,8 @@ abstract contract ERC3664Updatable is ERC3664, IERC3664Updatable {
             operator,
             0,
             tokenId,
-            _asSingletonArray(attrId),
-            _asSingletonArray(amount),
+            _as3664SingletonArray(attrId),
+            _as3664SingletonArray(amount),
             ""
         );
 
@@ -90,8 +90,8 @@ abstract contract ERC3664Updatable is ERC3664, IERC3664Updatable {
             operator,
             tokenId,
             0,
-            _asSingletonArray(attrId),
-            _asSingletonArray(amount),
+            _as3664SingletonArray(attrId),
+            _as3664SingletonArray(amount),
             ""
         );
 


### PR DESCRIPTION
My previous fix for this issue still requires modifying the ERC-1155 Openzeppelin contract, which is not reccomended. So this solution removes the conflict by changing the function name/signature. 

This is needed because it is expected that EIP-3664 and ERC-1155 be compatible.

Changed Functions:
_asSingletonArray  -> _as3664SingletonArray
_setURI -> _setAttrURI